### PR TITLE
Add randomized dirt paths for enemy waves

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -406,6 +406,69 @@ body {
     overflow: hidden;
 }
 
+.path-layer,
+.tower-layer,
+.enemy-layer,
+.projectile-layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.path-layer {
+    z-index: 1;
+    pointer-events: none;
+}
+
+.tower-layer {
+    z-index: 4;
+}
+
+.enemy-layer {
+    z-index: 5;
+}
+
+.projectile-layer {
+    z-index: 6;
+    pointer-events: none;
+}
+
+.path-segment {
+    position: absolute;
+    background: linear-gradient(180deg, #d2b48c 0%, #c49a6c 45%, #8b5a2b 100%);
+    box-shadow: 0 0 15px rgba(79, 39, 11, 0.55);
+    border-radius: 999px;
+    opacity: 0.95;
+}
+
+.path-segment::after {
+    content: '';
+    position: absolute;
+    inset: 12%;
+    border-radius: inherit;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.12) 0%, rgba(210, 180, 140, 0.3) 45%, rgba(139, 69, 19, 0.5) 100%);
+}
+
+.path-marker {
+    position: absolute;
+    width: 26px;
+    height: 26px;
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    box-shadow: 0 0 12px rgba(0, 0, 0, 0.4);
+    pointer-events: none;
+}
+
+.path-marker.start {
+    background: radial-gradient(circle, #d4f1b6 0%, #7fb069 55%, #2f5233 100%);
+}
+
+.path-marker.end {
+    background: radial-gradient(circle, #f7b4a2 0%, #d66652 55%, #7a261c 100%);
+}
+
 .tower-panel {
     background: rgba(61, 41, 20, 0.6);
     border: 2px solid #8b4513;
@@ -499,6 +562,7 @@ body {
     font-size: 1.5rem;
     background: rgba(61, 41, 20, 0.9);
     cursor: pointer;
+    z-index: 2;
 }
 
 .enemy {
@@ -511,6 +575,7 @@ body {
     justify-content: center;
     font-size: 1.2rem;
     transition: all 0.1s ease;
+    z-index: 2;
 }
 
 .enemy.goblin {


### PR DESCRIPTION
## Summary
- add path templates and helper utilities to draw randomized dirt tracks inspired by maps.png and reuse them when the field resizes
- refresh the enemy route at the start of each wave while spawning units and towers/projectiles on dedicated overlay layers
- style the new layers, dirt path segments, and markers so the route is visually distinct on the game field

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68cd8a1878ec83248e547a75ce308715