### PR TITLE
Render randomized dirt path as unified SVG stroke

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -422,6 +422,13 @@ body {
     pointer-events: none;
 }
 
+.path-svg {
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+    pointer-events: none;
+}
+
 .tower-layer {
     z-index: 4;
 }
@@ -433,22 +440,6 @@ body {
 .projectile-layer {
     z-index: 6;
     pointer-events: none;
-}
-
-.path-segment {
-    position: absolute;
-    background: linear-gradient(180deg, #d2b48c 0%, #c49a6c 45%, #8b5a2b 100%);
-    box-shadow: 0 0 15px rgba(79, 39, 11, 0.55);
-    border-radius: 999px;
-    opacity: 0.95;
-}
-
-.path-segment::after {
-    content: '';
-    position: absolute;
-    inset: 12%;
-    border-radius: inherit;
-    background: radial-gradient(circle, rgba(255, 255, 255, 0.12) 0%, rgba(210, 180, 140, 0.3) 45%, rgba(139, 69, 19, 0.5) 100%);
 }
 
 .path-marker {


### PR DESCRIPTION
## Summary
- replace the segmented div-based road with a single SVG stroke that follows the randomized path data
- add gradient and noise styling so the dirt lane feels like one cohesive track while keeping start/end markers
- remove the old segment styles and add rules for the SVG layer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cd8e90e9c88324ab16486be578dc47