### PR TITLE
Enhance tower defense path visuals and enemy pacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -392,21 +392,38 @@ body {
 
 .defense-content {
     display: grid;
-    grid-template-columns: 2fr 1fr;
-    gap: 2rem;
-    height: calc(100vh - 200px);
+    grid-template-columns: minmax(640px, 3fr) minmax(260px, 1fr);
+    gap: 2.5rem;
+    height: calc(100vh - 220px);
+    align-items: stretch;
 }
 
 .game-field {
-    background: rgba(61, 41, 20, 0.6);
-    border: 2px solid #8b4513;
-    border-radius: 10px;
     position: relative;
-    min-height: 500px;
+    min-height: 560px;
+    width: 100%;
+    height: 100%;
+    border: 2px solid #8b4513;
+    border-radius: 12px;
     overflow: hidden;
+    background: linear-gradient(180deg, rgba(62, 128, 44, 0.9) 0%, rgba(28, 63, 24, 0.9) 40%, rgba(22, 46, 20, 0.95) 100%),
+                radial-gradient(circle at top left, rgba(94, 150, 65, 0.4), transparent 55%),
+                radial-gradient(circle at bottom right, rgba(36, 80, 33, 0.45), transparent 60%);
+    box-shadow: inset 0 0 35px rgba(0, 0, 0, 0.45), 0 12px 24px rgba(0, 0, 0, 0.35);
+}
+
+.game-field::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 12px;
+    border: 3px solid rgba(139, 69, 19, 0.35);
+    pointer-events: none;
+    box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.35);
 }
 
 .path-layer,
+.scenery-layer,
 .tower-layer,
 .enemy-layer,
 .projectile-layer {
@@ -420,6 +437,12 @@ body {
 .path-layer {
     z-index: 1;
     pointer-events: none;
+}
+
+.scenery-layer {
+    z-index: 0;
+    pointer-events: none;
+    overflow: hidden;
 }
 
 .path-svg {
@@ -440,6 +463,39 @@ body {
 .projectile-layer {
     z-index: 6;
     pointer-events: none;
+}
+
+.scenery {
+    position: absolute;
+    pointer-events: none;
+    will-change: transform;
+}
+
+.scenery.tree {
+    font-size: 2.8rem;
+    filter: drop-shadow(0 8px 8px rgba(0, 0, 0, 0.35));
+    transition: transform 0.6s ease;
+}
+
+.scenery.grass {
+    width: 46px;
+    height: 16px;
+    background: radial-gradient(ellipse at center, rgba(108, 168, 78, 0.85) 0%, rgba(62, 128, 44, 0.85) 55%, rgba(30, 68, 28, 0.6) 100%);
+    border-radius: 50% / 60%;
+    box-shadow: 0 6px 10px rgba(0, 0, 0, 0.25);
+    opacity: 0.88;
+}
+
+.scenery.grass::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 25%;
+    transform: translateX(-50%);
+    width: 70%;
+    height: 70%;
+    background: radial-gradient(ellipse at center, rgba(152, 210, 112, 0.85) 0%, rgba(96, 160, 70, 0.6) 60%, rgba(40, 88, 36, 0) 100%);
+    border-radius: 50%;
 }
 
 .path-marker {


### PR DESCRIPTION
## Summary
- rework enemy movement to follow the generated path smoothly and reach the player after roughly thirty seconds
- rebuild map generation to fill the play area, decorate the borders with trees and grass, and clear leftovers between waves
- refresh the tower defense field styling to emphasize the dirt road against a grassy backdrop

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cd93b20b6c8324b603880f96dff2a1