### PR TITLE
Improve wave feedback and enemy visuals

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -623,6 +623,7 @@ body {
     font-size: 1.2rem;
     transition: all 0.1s ease;
     z-index: 2;
+    overflow: visible;
 }
 
 .enemy.goblin {
@@ -647,6 +648,63 @@ body {
     background: #d4af37;
     border-radius: 50%;
     z-index: 10;
+}
+
+.enemy-health-bar {
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    width: 36px;
+    height: 6px;
+    background: rgba(0, 0, 0, 0.6);
+    border: 1px solid rgba(0, 0, 0, 0.7);
+    border-radius: 4px;
+    overflow: hidden;
+    pointer-events: none;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.35);
+}
+
+.enemy-health-fill {
+    height: 100%;
+    width: 100%;
+    background: #4caf50;
+    transition: width 0.15s linear, background-color 0.15s linear;
+}
+
+.wave-status-message {
+    position: absolute;
+    top: 16px;
+    left: 50%;
+    transform: translate(-50%, -20px);
+    padding: 12px 18px;
+    background: rgba(26, 15, 10, 0.88);
+    border: 2px solid #d4af37;
+    border-radius: 8px;
+    color: #f4e4bc;
+    font-weight: bold;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.65);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    z-index: 25;
+}
+
+.wave-status-message.visible {
+    opacity: 1;
+    transform: translate(-50%, 0);
+}
+
+.wave-status-message.failure {
+    background: rgba(97, 15, 15, 0.9);
+    border-color: #d93025;
+    color: #ffe6e6;
+}
+
+.wave-status-message.success {
+    background: rgba(24, 70, 24, 0.9);
+    border-color: #6bbf59;
+    color: #f4ffef;
 }
 
 /* Responsive Design */


### PR DESCRIPTION
## Summary
- tie enemy speed to maximum health and update their health bars whenever damage is dealt
- create on-field wave failure messaging and enemy health bar DOM elements during spawns
- add styling for the new health indicators and map overlay messaging

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68cd9889665c8324adc069396c1b8001