### PR TITLE
Center failure notification and enlarge display

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -677,12 +677,13 @@ body {
     top: 16px;
     left: 50%;
     transform: translate(-50%, -20px);
-    padding: 12px 18px;
+    padding: 14px 21px;
     background: rgba(26, 15, 10, 0.88);
     border: 2px solid #d4af37;
     border-radius: 8px;
     color: #f4e4bc;
     font-weight: bold;
+    font-size: 1.15rem;
     text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.65);
     opacity: 0;
     pointer-events: none;
@@ -699,6 +700,12 @@ body {
     background: rgba(97, 15, 15, 0.9);
     border-color: #d93025;
     color: #ffe6e6;
+    top: 50%;
+    transform: translate(-50%, -55%);
+}
+
+.wave-status-message.failure.visible {
+    transform: translate(-50%, -50%);
 }
 
 .wave-status-message.success {


### PR DESCRIPTION
## Summary
- enlarge the wave status notification padding and font size by roughly 15%
- center failure status messages in the middle of the game field for better visibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cd9e3a691c8324a50f8a7db232e481