### PR TITLE
Implement tiered upgrades and resource drops

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,16 +38,6 @@
                         <input type="range" id="effects-volume" min="0" max="100" value="50">
                     </div>
                 </div>
-                
-                <div class="resources-section">
-                    <h3>Resources</h3>
-                    <div class="resources">
-                        <div class="resource gold">Gold: <span id="gold">1000</span></div>
-                        <div class="resource">🪵 Wood: <span id="wood">500</span></div>
-                        <div class="resource">🪨 Stone: <span id="stone">300</span></div>
-                        <div class="resource shards">Shards: <span id="shards">0</span></div>
-                    </div>
-                </div>
             </div>
         </div>
 
@@ -115,6 +105,7 @@
                     <span class="resource gold">Gold: <span id="city-gold">1000</span></span>
                     <span class="resource">🪵 Wood: <span id="city-wood">500</span></span>
                     <span class="resource">🪨 Stone: <span id="city-stone">300</span></span>
+                    <span class="city-population">Population: <span id="city-population">0</span></span>
                 </div>
             </div>
             <div class="city-content">

--- a/styles.css
+++ b/styles.css
@@ -282,6 +282,19 @@ body {
     margin: 0;
 }
 
+.city-population {
+    font-size: 1.1rem;
+    font-weight: bold;
+    color: #d4af37;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.city-population span {
+    color: #f4e4bc;
+}
+
 .city-content {
     display: grid;
     grid-template-columns: 2fr 1fr;
@@ -312,6 +325,7 @@ body {
     justify-content: center;
     font-size: 1.5rem;
     min-height: 60px;
+    position: relative;
 }
 
 .city-tile:hover {
@@ -321,7 +335,25 @@ body {
 
 .city-tile.occupied {
     background: #654321;
-    cursor: default;
+    cursor: pointer;
+}
+
+.city-tile .tile-icon {
+    font-size: 1.6rem;
+}
+
+.city-tile .tile-tier {
+    position: absolute;
+    bottom: 4px;
+    right: 4px;
+    background: rgba(26, 15, 10, 0.85);
+    border: 1px solid #d4af37;
+    border-radius: 6px;
+    padding: 2px 5px;
+    font-size: 0.75rem;
+    font-weight: bold;
+    color: #f4e4bc;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
 }
 
 .building-panel {
@@ -659,6 +691,24 @@ body {
     background: rgba(61, 41, 20, 0.9);
     cursor: pointer;
     z-index: 2;
+}
+
+.tower .tower-icon-display {
+    font-size: 1.4rem;
+}
+
+.tower .tower-tier {
+    position: absolute;
+    bottom: -10px;
+    right: -6px;
+    background: rgba(212, 175, 55, 0.9);
+    color: #1a0f0a;
+    border-radius: 8px;
+    padding: 1px 6px;
+    font-size: 0.7rem;
+    font-weight: bold;
+    border: 1px solid #8b4513;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
 }
 
 .enemy {


### PR DESCRIPTION
## Summary
- remove the redundant resource display from the settings screen and surface a live population counter in city management
- introduce tiered building and tower upgrades with escalating resource costs, level indicators, and production/health scaling
- expand enemy rewards to drop gold, wood, stone, and rare shards while updating UI feedback for tower tiers and drops

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68cdb35153388324ae3a71f2e16b7c31