### PR TITLE
Implement citizen management and food upkeep

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,7 +224,8 @@
                         <span id="health-value">100 / 100</span>
                     </div>
                     <span class="resource gold">Gold: <span id="defense-gold">500</span></span>
-                    <span class="resource">🍞 Food: <span id="defense-food">50</span></span>
+                    <span class="resource">🪵 Wood: <span id="defense-wood">50</span></span>
+                    <span class="resource">🪨 Stone: <span id="defense-stone">50</span></span>
                     <span class="resource shards">Shards: <span id="defense-shards">0</span></span>
                 </div>
             </div>
@@ -262,6 +263,21 @@
                                 <p>Cost: 250 Gold</p>
                             </div>
                         </div>
+                    </div>
+                    <div class="speed-control">
+                        <div class="speed-control-header">
+                            <label for="speed-slider">Game Speed</label>
+                            <span id="speed-value" class="speed-current">1x</span>
+                        </div>
+                        <input type="range" id="speed-slider" min="1" max="5" step="1" value="1" aria-valuemin="1" aria-valuemax="5" aria-valuenow="1" aria-valuetext="1x" aria-label="Tower defense speed">
+                        <div class="speed-marks">
+                            <span>1x</span>
+                            <span>2x</span>
+                            <span>3x</span>
+                            <span>4x</span>
+                            <span>5x</span>
+                        </div>
+                        <small class="speed-hint">Slide to boost waves to 2x, 3x, 4x, or 5x speed.</small>
                     </div>
                     <div class="game-controls">
                         <button id="start-wave" class="control-btn">Start Wave</button>

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
                     <span class="resource gold">Gold: <span id="shop-gold">1000</span></span>
                     <span class="resource">🪵 Wood: <span id="shop-wood">500</span></span>
                     <span class="resource">🪨 Stone: <span id="shop-stone">300</span></span>
+                    <span class="resource">🍞 Food: <span id="shop-food">200</span></span>
                     <span class="resource shards">Shards: <span id="shop-shards">0</span></span>
                 </div>
             </div>
@@ -71,9 +72,14 @@
                             <p>Cost: 300 Gold, 50 Stone</p>
                             <button class="buy-btn" data-item="quarry">Buy</button>
                         </div>
+                        <div class="shop-item">
+                            <h4>🌾 Farm</h4>
+                            <p>Cost: 150 Gold, 75 Wood</p>
+                            <button class="buy-btn" data-item="farm">Buy</button>
+                        </div>
                     </div>
                 </div>
-                
+
                 <div class="shop-section">
                     <h3>Shards</h3>
                     <div class="shop-items">
@@ -105,7 +111,22 @@
                     <span class="resource gold">Gold: <span id="city-gold">1000</span></span>
                     <span class="resource">🪵 Wood: <span id="city-wood">500</span></span>
                     <span class="resource">🪨 Stone: <span id="city-stone">300</span></span>
-                    <span class="city-population">Population: <span id="city-population">0</span></span>
+                    <span class="resource">🍞 Food: <span id="city-food">200</span></span>
+                    <span class="city-population">Citizens: <span id="city-population">0 / 0</span></span>
+                </div>
+            </div>
+            <div class="citizen-overview">
+                <div class="citizen-stats">
+                    <span>Total Citizens: <span id="citizen-count">0 / 0</span></span>
+                    <span>Unassigned: <span id="citizen-unassigned">0</span></span>
+                    <span>Daily Food Need: <span id="daily-food-requirement">0</span></span>
+                </div>
+                <div class="food-status">
+                    <span class="food-amount">🍞 Stored Food: <span id="food-amount">200</span></span>
+                    <div class="food-bar">
+                        <div class="food-bar-fill" id="food-bar-fill"></div>
+                    </div>
+                    <small>Food bar depletes over a full day of rations</small>
                 </div>
             </div>
             <div class="city-content">
@@ -121,6 +142,7 @@
                                 <h4>House</h4>
                                 <p>+5 Population</p>
                                 <p>Cost: 100 Gold, 50 Wood</p>
+                                <p>No upkeep required</p>
                             </div>
                         </div>
                         <div class="building-option" data-building="lumber-mill">
@@ -128,6 +150,8 @@
                             <div class="building-info">
                                 <h4>Lumber Mill</h4>
                                 <p>+10 Wood/hour</p>
+                                <p>Upkeep: 2 Gold/hour</p>
+                                <p>Requires up to 5 citizens for full output</p>
                                 <p>Cost: 200 Gold, 100 Wood</p>
                             </div>
                         </div>
@@ -136,23 +160,39 @@
                             <div class="building-info">
                                 <h4>Stone Quarry</h4>
                                 <p>+8 Stone/hour</p>
+                                <p>Upkeep: 3 Gold/hour</p>
+                                <p>Requires up to 10 citizens for full output</p>
                                 <p>Cost: 300 Gold, 50 Stone</p>
+                            </div>
+                        </div>
+                        <div class="building-option" data-building="farm">
+                            <div class="building-icon">🌾</div>
+                            <div class="building-info">
+                                <h4>Farm</h4>
+                                <p>+12 Food/hour</p>
+                                <p>Upkeep: 2 Gold, 1 Wood/hour</p>
+                                <p>Requires up to 6 citizens for full output</p>
+                                <p>Cost: 150 Gold, 75 Wood</p>
                             </div>
                         </div>
                         <div class="building-option" data-building="barracks">
                             <div class="building-icon">🏰</div>
                             <div class="building-info">
                                 <h4>Barracks</h4>
-                                <p>Train Soldiers</p>
-                                <p>Cost: 500 Gold, 200 Wood</p>
+                                <p>Required: 10 Citizens per barracks owned</p>
+                                <p>Supports 1 tower when fully staffed</p>
+                                <p>Upkeep: 5 Gold/hour</p>
+                                <p>Requires up to 10 citizens for full training</p>
+                                <p>Cost: 300 Gold, 10 Wood, 10 Stone</p>
                             </div>
                         </div>
                         <div class="building-option" data-building="hospital">
                             <div class="building-icon">🏥</div>
                             <div class="building-info">
                                 <h4>Hospital</h4>
-                                <p>+15% Max Health</p>
+                                <p>+15% Max Health when fully staffed</p>
                                 <p>Upkeep: 15 Gold, 5 Wood, 5 Stone per hour</p>
+                                <p>Requires up to 20 citizens for full care</p>
                                 <p>Cost: 450 Gold, 150 Wood, 150 Stone</p>
                             </div>
                         </div>
@@ -175,6 +215,7 @@
                         <span id="health-value">100 / 100</span>
                     </div>
                     <span class="resource gold">Gold: <span id="defense-gold">1000</span></span>
+                    <span class="resource">🍞 Food: <span id="defense-food">200</span></span>
                 </div>
             </div>
             <div class="defense-content">

--- a/index.html
+++ b/index.html
@@ -46,10 +46,10 @@
             <div class="screen-header">
                 <h2>Shop</h2>
                 <div class="shop-resources">
-                    <span class="resource gold">Gold: <span id="shop-gold">1000</span></span>
-                    <span class="resource">🪵 Wood: <span id="shop-wood">500</span></span>
-                    <span class="resource">🪨 Stone: <span id="shop-stone">300</span></span>
-                    <span class="resource">🍞 Food: <span id="shop-food">200</span></span>
+                    <span class="resource gold">Gold: <span id="shop-gold">500</span></span>
+                    <span class="resource">🪵 Wood: <span id="shop-wood">50</span></span>
+                    <span class="resource">🪨 Stone: <span id="shop-stone">50</span></span>
+                    <span class="resource">🍞 Food: <span id="shop-food">50</span></span>
                     <span class="resource shards">Shards: <span id="shop-shards">0</span></span>
                 </div>
             </div>
@@ -108,10 +108,11 @@
             <div class="screen-header">
                 <h2>City Management</h2>
                 <div class="city-resources">
-                    <span class="resource gold">Gold: <span id="city-gold">1000</span></span>
-                    <span class="resource">🪵 Wood: <span id="city-wood">500</span></span>
-                    <span class="resource">🪨 Stone: <span id="city-stone">300</span></span>
-                    <span class="resource">🍞 Food: <span id="city-food">200</span></span>
+                    <span class="resource gold">Gold: <span id="city-gold">500</span></span>
+                    <span class="resource">🪵 Wood: <span id="city-wood">50</span></span>
+                    <span class="resource">🪨 Stone: <span id="city-stone">50</span></span>
+                    <span class="resource">🍞 Food: <span id="city-food">50</span></span>
+                    <span class="resource shards">Shards: <span id="city-shards">0</span></span>
                     <span class="city-population">Citizens: <span id="city-population">0 / 0</span></span>
                 </div>
             </div>
@@ -122,7 +123,7 @@
                     <span>Daily Food Need: <span id="daily-food-requirement">0</span></span>
                 </div>
                 <div class="food-status">
-                    <span class="food-amount">🍞 Stored Food: <span id="food-amount">200</span></span>
+                    <span class="food-amount">🍞 Stored Food: <span id="food-amount">50</span></span>
                     <div class="food-bar">
                         <div class="food-bar-fill" id="food-bar-fill"></div>
                     </div>
@@ -135,6 +136,7 @@
                 </div>
                 <div class="building-panel">
                     <h3>Available Buildings</h3>
+                    <p class="upgrade-note">Tier upgrades require shards (T2 5, T3 20, T4 50, T5 100). Destroying a building refunds 50% of all resources spent on it.</p>
                     <div class="building-options">
                         <div class="building-option" data-building="house">
                             <div class="building-icon">🏠</div>
@@ -214,8 +216,9 @@
                         </div>
                         <span id="health-value">100 / 100</span>
                     </div>
-                    <span class="resource gold">Gold: <span id="defense-gold">1000</span></span>
-                    <span class="resource">🍞 Food: <span id="defense-food">200</span></span>
+                    <span class="resource gold">Gold: <span id="defense-gold">500</span></span>
+                    <span class="resource">🍞 Food: <span id="defense-food">50</span></span>
+                    <span class="resource shards">Shards: <span id="defense-shards">0</span></span>
                 </div>
             </div>
             <div class="defense-content">

--- a/index.html
+++ b/index.html
@@ -38,6 +38,13 @@
                         <input type="range" id="effects-volume" min="0" max="100" value="50">
                     </div>
                 </div>
+                <div class="settings-section">
+                    <h3>Game Management</h3>
+                    <div class="setting-item single-action">
+                        <button id="reset-game" class="control-btn reset-btn">Reset Game</button>
+                        <small class="reset-warning">Restores your kingdom to its initial state.</small>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -259,7 +266,6 @@
                     <div class="game-controls">
                         <button id="start-wave" class="control-btn">Start Wave</button>
                         <button id="pause-game" class="control-btn">Pause</button>
-                        <button id="reset-game" class="control-btn">Reset Game</button>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
                             <div class="building-icon">🏠</div>
                             <div class="building-info">
                                 <h4>House</h4>
-                                <p>+5 Population</p>
+                                <p>Population per Tier: +5 / +10 / +15 / +20 / +30</p>
                                 <p>Cost: 100 Gold, 50 Wood</p>
                                 <p>No upkeep required</p>
                             </div>

--- a/styles.css
+++ b/styles.css
@@ -282,7 +282,7 @@ body {
     margin: 0;
 }
 
-.city-population {
+.city-population { 
     font-size: 1.1rem;
     font-weight: bold;
     color: #d4af37;
@@ -293,6 +293,59 @@ body {
 
 .city-population span {
     color: #f4e4bc;
+}
+
+.citizen-overview {
+    background: rgba(61, 41, 20, 0.6);
+    border: 2px solid #8b4513;
+    border-radius: 10px;
+    padding: 1rem 1.5rem;
+    margin: 1rem 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.citizen-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    font-weight: bold;
+}
+
+.citizen-stats span {
+    color: #f4e4bc;
+}
+
+.food-status {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.food-amount {
+    font-weight: bold;
+}
+
+.food-bar {
+    width: 100%;
+    height: 14px;
+    background: rgba(26, 15, 10, 0.85);
+    border: 1px solid #d4af37;
+    border-radius: 7px;
+    overflow: hidden;
+    box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.4);
+}
+
+.food-bar-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #4caf50 0%, #cddc39 100%);
+    transition: width 0.5s ease;
+}
+
+.food-status small {
+    color: #d4af37;
+    opacity: 0.85;
 }
 
 .city-content {
@@ -353,6 +406,20 @@ body {
     font-size: 0.75rem;
     font-weight: bold;
     color: #f4e4bc;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+.city-tile .tile-citizens {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    background: rgba(26, 15, 10, 0.85);
+    border: 1px solid #4caf50;
+    border-radius: 6px;
+    padding: 2px 6px;
+    font-size: 0.75rem;
+    font-weight: bold;
+    color: #cddc39;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -735,6 +735,86 @@ body {
     margin-bottom: 0.2rem;
 }
 
+.speed-control {
+    background: rgba(26, 15, 10, 0.8);
+    border: 1px solid rgba(139, 69, 19, 0.8);
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+    box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.35);
+}
+
+.speed-control-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: #d4af37;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.speed-current {
+    color: #f6c177;
+    font-size: 1rem;
+}
+
+.speed-control input[type="range"] {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 6px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, rgba(212, 175, 55, 0.65), rgba(246, 193, 119, 0.65));
+    outline: none;
+    cursor: pointer;
+    box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.5);
+}
+
+.speed-control input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: linear-gradient(145deg, #d4af37, #a67c00);
+    border: 2px solid rgba(246, 193, 119, 0.85);
+    box-shadow: 0 0 10px rgba(246, 193, 119, 0.45);
+    transition: transform 0.2s ease;
+}
+
+.speed-control input[type="range"]::-moz-range-thumb {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: linear-gradient(145deg, #d4af37, #a67c00);
+    border: 2px solid rgba(246, 193, 119, 0.85);
+    box-shadow: 0 0 10px rgba(246, 193, 119, 0.45);
+    transition: transform 0.2s ease;
+}
+
+.speed-control input[type="range"]::-webkit-slider-thumb:hover,
+.speed-control input[type="range"]::-moz-range-thumb:hover {
+    transform: scale(1.1);
+}
+
+.speed-marks {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+    color: rgba(244, 228, 188, 0.75);
+    letter-spacing: 0.06em;
+}
+
+.speed-hint {
+    color: rgba(244, 228, 188, 0.8);
+    font-size: 0.8rem;
+    letter-spacing: 0.03em;
+}
+
 .game-controls {
     display: flex;
     flex-direction: column;

--- a/styles.css
+++ b/styles.css
@@ -437,6 +437,14 @@ body {
     font-size: 1.5rem;
 }
 
+.upgrade-note {
+    font-size: 0.95rem;
+    color: #f9e8c5;
+    margin-bottom: 1rem;
+    line-height: 1.4;
+    font-style: italic;
+}
+
 .building-options {
     display: flex;
     flex-direction: column;

--- a/styles.css
+++ b/styles.css
@@ -129,6 +129,16 @@ body {
     gap: 1rem;
 }
 
+.setting-item.single-action {
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.setting-item.single-action .control-btn {
+    width: 100%;
+    max-width: 240px;
+}
+
 .setting-item label {
     min-width: 100px;
     font-weight: bold;
@@ -746,6 +756,21 @@ body {
 .control-btn:hover {
     background: linear-gradient(145deg, #a0522d, #8b4513);
     transform: translateY(-2px);
+}
+
+.reset-btn {
+    background: linear-gradient(145deg, #8b1a1a, #5c0a0a);
+    border-color: #ff9f43;
+}
+
+.reset-btn:hover {
+    background: linear-gradient(145deg, #a62929, #751212);
+}
+
+.reset-warning {
+    color: #f6c177;
+    font-size: 0.85rem;
+    display: block;
 }
 
 .control-btn:active {


### PR DESCRIPTION
## Summary
- add food resource tracking, citizen overview UI, and a farm building option
- assign citizens to productivity-dependent buildings, apply upkeep, and manage food consumption/starvation in game logic
- gate tower construction by staffed barracks and display assigned citizens per building tile

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_b_68cdbb4982348324999421f8dd9f635d