### PR TITLE
Fix UI scene syntax to restore game view

### DIFF
--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -360,8 +360,7 @@ export default class UIScene extends Phaser.Scene {
       descriptionLines.push(`Tower Support: ${building.towerSupport}`);
     }
 
-    const desc = this.add.text(0, 26, descriptionLines.join('
-'), {
+    const desc = this.add.text(0, 26, descriptionLines.join('\n'), {
       fontFamily: 'Cinzel',
       fontSize: '14px',
       color: '#b6c1d1',
@@ -536,7 +535,7 @@ export default class UIScene extends Phaser.Scene {
       onChange(current);
     };
 
-    const minus = this.createSmallButton(-20, 0, '−', () => {
+    const minus = this.createSmallButton(-20, 0, '-', () => {
       emitChange(current - 10);
     });
     const plus = this.createSmallButton(90, 0, '+', () => {


### PR DESCRIPTION
## Summary
- replace the Unicode minus in the UI volume control with a standard hyphen
- update the building description joiner to use a literal newline so the module parses correctly

## Testing
- browser_container.run_playwright_script  # Loaded title: Kingdoms Last Stand

------
https://chatgpt.com/codex/tasks/task_b_68ce0ed80adc832a80e058a7987a0bf9